### PR TITLE
fixed match for multi-character emoji

### DIFF
--- a/emojis/emojis.py
+++ b/emojis/emojis.py
@@ -4,11 +4,12 @@ from . import db
 
 ALIAS_TO_EMOJI = db.get_emoji_aliases()
 EMOJI_TO_ALIAS = dict((v, k) for k, v in ALIAS_TO_EMOJI.items())
+EMOJI_TO_ALIAS_SORTED = sorted(ALIAS_TO_EMOJI.values(), key=len, reverse=True)
 
 RE_TEXT_TO_EMOJI_GROUP = '({0})'.format('|'.join([re.escape(emoji) for emoji in ALIAS_TO_EMOJI]))
 RE_TEXT_TO_EMOJI = re.compile(RE_TEXT_TO_EMOJI_GROUP)
 
-RE_EMOJI_TO_TEXT_GROUP = '({0})'.format('|'.join([re.escape(emoji) for emoji in EMOJI_TO_ALIAS]))
+RE_EMOJI_TO_TEXT_GROUP = '({0})'.format('|'.join([re.escape(emoji) for emoji in EMOJI_TO_ALIAS_SORTED]))
 RE_EMOJI_TO_TEXT = re.compile(RE_EMOJI_TO_TEXT_GROUP)
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -26,6 +26,10 @@ class TestEmoji(unittest.TestCase):
         emoji = emojis.get('Prefix 😄 ❤️ 😄 ❤️ Sufix')
         self.assertEqual(emoji, {'😄', '❤️'})
 
+    def test_get_multi_character(self):
+        emoji = emojis.get('Prefix 👨‍🎓 👨‍🎓 Sufix')
+        self.assertEqual(emoji, {'👨‍🎓'})
+
     def test_count(self):
         count = emojis.count('😄 ❤️ 😄 ❤️')
         self.assertEqual(count, 4)


### PR DESCRIPTION
Sort emojis from longest to shortest characters to make sure longest matched first